### PR TITLE
WIP: refactor config::add with explicit Config argument.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,8 @@ fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Add { message } => {
-            let fixme = config::add(&message)?;
+            let mut conf = config::Config::load()?;
+            let fixme = config::add(&mut conf, &message)?;
             println!("{}", fixme);
             Ok(())
         }


### PR DESCRIPTION
Testing the config::add method was almost impossible with so much internal state resolved by current_dir.

Additionally, loading the Config object from disk meant tests could only be written against the config as it exists on the machine they are ran from. This would make it impossible to make good or interesting tests.

Passing a Config object into the config::add method means we can control the structure of the object and therefore define good tests which handle edge cases.

<!-- ps-id: 72aba157-2f49-49b7-8ca7-0c75bce845b7 -->