### PR TITLE
Migrate primary methods to separate modules.

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,0 +1,52 @@
+use crate::config::{Config, Fixme};
+
+pub fn add(conf: &mut Config, fixme: Fixme) -> std::io::Result<&Fixme> {
+    for project in &mut conf.projects {
+        for path in fixme.location.ancestors() {
+            if path == project.location() {
+                return Ok(project.add_fixme(fixme));
+            }
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "No project initialized for this directory. run 'fixme init' first",
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::config::{Config, Project};
+
+    #[test]
+    fn add_fixme_when_no_matching_project_is_err() -> std::io::Result<()> {
+        let mut conf = Config::new();
+        let fixme = Fixme::new_in_current_dir("hello")?;
+        assert!(add(&mut conf, fixme).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn add_fixme_when_fixme_in_project_location_is_ok() -> std::io::Result<()> {
+        let mut conf = Config::new();
+        let current_dir = std::env::current_dir()?;
+        let current_dir = std::fs::canonicalize(current_dir)?;
+        let project = Project::new(current_dir.clone());
+        conf.projects.push(project);
+        let fixme = Fixme::new_in_current_dir("")?;
+        add(&mut conf, fixme).map(|_| ())
+    }
+
+    #[test]
+    fn add_fixme_when_fixme_is_child_dir_of_project() -> std::io::Result<()> {
+        let mut conf = Config::new();
+        let current_dir = std::env::current_dir()?;
+        let current_dir = std::fs::canonicalize(current_dir)?;
+        let project = Project::new(current_dir.clone());
+        conf.projects.push(project);
+        let fixme_loc = current_dir.join("bar");
+        let fixme = Fixme::new(fixme_loc, "");
+        add(&mut conf, fixme).map(|_| ())
+    }
+}

--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -1,0 +1,11 @@
+use crate::config::Config;
+
+#[derive(Debug)]
+pub struct FixId {
+    pub project_id: u8,
+    pub fixme_id: u8,
+}
+
+pub fn fix(_conf: &mut Config, id: FixId) {
+    println!("Fixing id: {id:?}");
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,26 @@
+use crate::config::{Config, Project};
+
+/// Creates a project in the configuration file with location set to current directory.
+pub fn initialize_project(conf: &mut Config) -> std::io::Result<()> {
+    let current_dir = std::env::current_dir()?;
+    let current_dir = std::fs::canonicalize(current_dir)?;
+    if conf
+        .projects
+        .iter()
+        .filter(|p| p.location() == current_dir)
+        .count()
+        == 0
+    {
+        println!("No projects found for: {:?}.", current_dir);
+        conf.projects.push(Project::new(current_dir.clone()));
+        conf.save()?;
+        println!(
+            "Updated configuration with new project for: {:?}",
+            current_dir
+        );
+        return Ok(());
+    } else {
+        println!("Project for this directory already exists.");
+    }
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod add;
+pub mod fix;
+pub mod init;


### PR DESCRIPTION
This also adds a cleaner list display by taking the project name from
the last path segment of the project's location.

As these commands grow, providing a publicly exposed and privately
implemented definition of each Cli::command will become more and more
helpful.

<!-- ps-id: d1c0797b-caf7-41d4-8485-deabc4ee7b60 -->