### PR TITLE
WIP: Add dedicated list module to support list command

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,32 @@
+use crate::config::{Config, Fixme, Project};
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum ListScope {
+    Directory,
+    Project,
+    All,
+}
+
+pub fn list(conf: &Config, scope: ListScope) -> std::io::Result<Vec<(&Project, &Fixme)>> {
+    let cur_dir = std::env::current_dir()?;
+    let cur_dir = std::fs::canonicalize(cur_dir)?;
+    let mut fixmes: Vec<(&Project, &Fixme)> = vec![];
+    for project in &conf.projects {
+        if (scope == ListScope::All)
+            || (scope == ListScope::Project && project.is_path_in_project(&cur_dir))
+        {
+            for fixme in project.fixmes() {
+                fixmes.push((&project, fixme));
+            }
+        } else if scope == ListScope::Directory && project.is_path_in_project(&cur_dir) {
+            for fixme in project.fixmes() {
+                if fixme.location == cur_dir {
+                    fixmes.push((&project, fixme));
+                }
+            }
+        }
+    }
+    fixmes.sort_by_key(|f| f.1.created);
+    fixmes.reverse();
+    Ok(fixmes)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod add;
 pub mod fix;
 pub mod init;
+pub mod list;

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,10 @@ impl Project {
         self.fixmes.push(fixme);
         self.fixmes.last().unwrap()
     }
+
+    pub fn fixmes(&self) -> &Vec<Fixme> {
+        &self.fixmes
+    }
 }
 
 impl Fixme {


### PR DESCRIPTION
List was the last remaining command still handled by the config
module. This implements the functionality in a dedicated module, list,
just like the rest of the commands exposed by Cli.

<!-- ps-id: 02b85365-2644-49e2-aa7a-5195f5bfcbf8 -->