### PR TITLE
WIP: Remove the redundant `list_fixmes` from the config module.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -97,13 +97,6 @@ impl Fixme {
     }
 }
 
-#[derive(PartialEq, Eq, Debug)]
-pub enum ListScope {
-    Directory,
-    Project,
-    All,
-}
-
 impl fmt::Display for Fixme {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -135,30 +128,6 @@ impl Config {
         let contents = toml::to_string(&self).expect("Config object to serialize to toml");
         println!("Saving config...");
         std::fs::write(path, contents)
-    }
-
-    pub fn list_fixmes(&self, scope: ListScope) -> std::io::Result<Vec<(&Project, &Fixme)>> {
-        let cur_dir = std::env::current_dir()?;
-        let cur_dir = std::fs::canonicalize(cur_dir)?;
-        let mut fixmes: Vec<(&Project, &Fixme)> = vec![];
-        for project in &self.projects {
-            if (scope == ListScope::All)
-                || (scope == ListScope::Project && project.is_path_in_project(&cur_dir))
-            {
-                for fixme in &project.fixmes {
-                    fixmes.push((&project, fixme));
-                }
-            } else if scope == ListScope::Directory && project.is_path_in_project(&cur_dir) {
-                for fixme in &project.fixmes {
-                    if fixme.location == cur_dir {
-                        fixmes.push((&project, fixme));
-                    }
-                }
-            }
-        }
-        fixmes.sort_by_key(|f| f.1.created);
-        fixmes.reverse();
-        Ok(fixmes)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
+use crate::commands::list::ListScope;
 use clap::{Args, Parser, Subcommand};
-use config::ListScope;
 
 use crate::config::Fixme;
 
@@ -47,7 +47,7 @@ struct Scope {
     all: bool,
 }
 
-impl From<Scope> for config::ListScope {
+impl From<Scope> for commands::list::ListScope {
     fn from(value: Scope) -> Self {
         let Scope { project, all } = value;
         match (project, all) {
@@ -90,7 +90,7 @@ fn main() -> std::io::Result<()> {
                     Err(err)
                 }
                 Ok(conf) => {
-                    for (project, fix) in conf.list_fixmes(ListScope::from(scope))? {
+                    for (project, fix) in commands::list::list(&conf, ListScope::from(scope))? {
                         println!(
                             "[{date}] {location}: (/{folder}) {message}",
                             date = fix.created.naive_local(),


### PR DESCRIPTION
Because of the list module, `crate::config::list_fixmes` is no longer
necessary. This method is removed and the main command dispatch logic
is updated to make use of the crate::commands::list::list method.

<!-- ps-id: 97b5aca9-c50d-4f6f-83ac-68814b642aa4 -->