### PR TITLE
WIP: Add FixmeStatus to Fixme struct

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,13 @@ pub struct Fixme {
     pub message: String,
     pub location: PathBuf,
     pub created: DateTime<Utc>,
+    pub status: FixmeStatus,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum FixmeStatus {
+    Active,
+    Complete,
 }
 
 /// Given a parent path and some path, return the fragment of the path after it.
@@ -93,6 +100,7 @@ impl Fixme {
             message: message.to_string(),
             location,
             created: Utc::now(),
+            status: FixmeStatus::Active,
         }
     }
 }


### PR DESCRIPTION
This adds a enum consisting of Active and Complete to the Fixme
struct. When viewing and completing fixmes, having a indication of
whether this fixme has already been done or not is essential.

"Completing" fixmes *could* have been accomplished by simply removing
them from the configuration file, but being able to see completed
fixmes could be helpful as well. Additionally this could pave the way
for an "undo" command later on.

<!-- ps-id: cb9ecf90-0afe-4c57-958a-023301c20f24 -->