### PR TITLE
update commands::list::list to reference project.active_fixme

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -15,11 +15,11 @@ pub fn list(conf: &Config, scope: ListScope) -> std::io::Result<Vec<(&Project, &
         if (scope == ListScope::All)
             || (scope == ListScope::Project && project.is_path_in_project(&cur_dir))
         {
-            for fixme in project.fixmes() {
+            for fixme in project.active_fixmes() {
                 fixmes.push((&project, fixme));
             }
         } else if scope == ListScope::Directory && project.is_path_in_project(&cur_dir) {
-            for fixme in project.fixmes() {
+            for fixme in project.active_fixmes() {
                 if fixme.location == cur_dir {
                     fixmes.push((&project, fixme));
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,10 +83,6 @@ impl Project {
         self.fixmes.last().unwrap()
     }
 
-    pub fn fixmes(&self) -> &Vec<Fixme> {
-        &self.fixmes
-    }
-
     pub fn active_fixmes(&self) -> Vec<&Fixme> {
         let result = self
             .fixmes


### PR DESCRIPTION
Updating this method to use the `active_fixmes` method means Cli::List
now only shows active fixmes.

<!-- ps-id: 80512594-33af-4b22-ad72-9307db8c52f3 -->
