### PR TITLE
Refactor commands::list::list to use IndexedFixme struct.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,16 +84,8 @@ fn main() -> std::io::Result<()> {
         }
         Command::List { filter: _, scope } => {
             let conf = config::Config::load()?;
-            for (project, fix) in commands::list::list(&conf, ListScope::from(scope))? {
-                println!(
-                    "[{date}] {location}: (/{folder}) {message}",
-                    date = fix.created.naive_local(),
-                    location = project.name(),
-                    folder = config::remove_ancestors(project.location(), &fix.location)
-                        .to_str()
-                        .unwrap(),
-                    message = fix.message,
-                );
+            for indexed_fixme in commands::list::list(&conf, ListScope::from(scope))? {
+                println!("{}", indexed_fixme);
             }
             Ok(())
         }


### PR DESCRIPTION
The `IndexedFixme` struct was built to store information about the
identifiers of a fixme and its project. Simply calling
`.iter().enumerate()` gives us such an identifier for both. And
because `list` now returns a `Vec` of `IndexedFixme`, we can simply
use the `Display` trait implemented on it, which allows us to clean up
the main loop.

<!-- ps-id: cba2b57a-4f1a-444a-8209-285d6e226c87 -->
