### PR TITLE
Clean up fixme listing display

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -19,7 +19,7 @@ impl fmt::Display for IndexedFixme<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "[{date}] id: {project_id}-{fixme_id}, name: {location}, dir: /{folder}, {message}",
+            "[{date}] {project_id} {fixme_id}: ({location}) [/{folder}], {message}",
             date = self.fixme.created.naive_local(),
             location = self.project.name(),
             project_id = self.project_id,


### PR DESCRIPTION
There were many explicit UI elements that made the display overly busy
and difficult to parse at a glance. This removes many of them but
wraps different elements in some form of bracketing.

Additionally, the hyphen between the project id and fixme id has been
removed to mitigate confusion. When fixing or deleting a fixme, the
project id and the fixme id need to be specified space-delimited, but
the former UI presented them hyphen-delimited.

<!-- ps-id: b4303691-154b-46fd-ba26-85cd0e4e8337 -->